### PR TITLE
Take version number from publication workflow and use it for website front page & footer

### DIFF
--- a/bin/put-version-number.sh
+++ b/bin/put-version-number.sh
@@ -4,7 +4,7 @@
 # SPDX-FileCopyrightText: Copyright 2026 The SPDX Contributors
 #
 # Replace version placeholders in the repository files.
-# Usage: put-version-number.sh VERSION DEFAULT_VERSION [file...]
+# Usage: put-version-number.sh VERSION VERSION_DEFAULT [file...]
 # If no files are provided, the script updates the following defaults:
 # - docs/index.md
 # - mkdocs.yml
@@ -14,9 +14,9 @@ set -eu
 
 usage() {
 	cat <<EOF >&2
-Usage: $0 VERSION DEFAULT_VERSION [file...]
+Usage: $0 VERSION VERSION_DEFAULT [file...]
 
-Replaces __VERSION__ and __DEFAULT_VERSION__ placeholders in the given files.
+Replaces __VERSION__ and __VERSION_DEFAULT__ placeholders in the given files.
 If no files are provided, the defaults are: docs/index.md mkdocs.yml setup.py
 EOF
 	exit 2
@@ -27,7 +27,7 @@ if [ "$#" -lt 2 ]; then
 fi
 
 VERSION=$1
-DEFAULT_VERSION=$2
+VERSION_DEFAULT=$2
 shift 2
 
 if [ "$#" -gt 0 ]; then
@@ -46,7 +46,7 @@ for f in $FILES; do
 	fi
 
 	tmp="${f}.tmp.${timestamp}"
-	awk -v v="$VERSION" -v dv="$DEFAULT_VERSION" '{ gsub(/__VERSION__/, v); gsub(/__DEFAULT_VERSION__/, dv); print }' "$f" > "$tmp" && mv "$tmp" "$f"
+	awk -v v="$VERSION" -v dv="$VERSION_DEFAULT" '{ gsub(/__VERSION__/, v); gsub(/__VERSION_DEFAULT__/, dv); print }' "$f" > "$tmp" && mv "$tmp" "$f"
 	echo "Updated: $f"
 done
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,7 @@ plugins:
 - search
 - mike:
     canonical_version: v__VERSION_DEFAULT__  # Tell search engines to prefer the URL of the default version.
-                                            # This should matches with VERSION_DEFAULT in .github/workflows/publish_v3yml
+                                             # This should matches with VERSION_DEFAULT in .github/workflows/publish_v3yml
     alias_type: redirect       # use "redirect" so it can redirect every pages (not just the root of the version)
 # - pdf-export:
 #     combined: true


### PR DESCRIPTION
Instead of having to adjust the version number manually in files at every releases,
this change will take the version number from the publication workflow variable
and place it relevant files:

- docs/index.md - for front page
- mkdocs.yml - for header and copyright footer
- setup.py - not currently in use, but just in case

This should reduce work and bring better consistency.

Changes in this PR:

- Version number strings in docs/index.md, mkdocs.yml, setup.py are replaced by `__VERSION__` and `__VERSION_DEFAULT__` placeholders
- Add a script to replace the placeholder in those files with an actual version number string during the publication workflow
- The replacement will be temporary during the workflow. In GitHub repo, the version will always be the placeholder.

docs/index.md, mkdocs.yml, and setup.py will still work locally (for testing purpose),
as the placeholder is just a string - same as the version number string.
